### PR TITLE
Move the export driver list to paths/strings

### DIFF
--- a/cpp/CWFGM_Scenario.Serialize.cpp
+++ b/cpp/CWFGM_Scenario.Serialize.cpp
@@ -42,17 +42,17 @@
 
 
 HRESULT CCWFGM_Scenario::ExportFires(const CCWFGM_Ignition *set, HSS_Time::WTime &start_time, HSS_Time::WTime &end_time, std::uint16_t flags,
-    const std::string &driver_name, const std::string &projection, const std::string &file_path, const ScenarioExportRules *rules) const {
+    std::string_view driver_name, const std::string &projection, const std::filesystem::path &file_path, const ScenarioExportRules *rules) const {
 	if ((!start_time.GetTotalMicroSeconds()) || (!end_time.GetTotalMicroSeconds()))			return ERROR_FIRE_INVALID_TIME;
 	if (!driver_name.length())								return E_POINTER;
-	if (!file_path.length())									return E_POINTER;
+	if (file_path.empty())									return E_POINTER;
 
 	CRWThreadSemaphoreEngage _semaphore_engage(const_cast<CRWThreadSemaphore &>(m_lock), SEM_FALSE);
 
 	if (m_impl->m_scenario) {
 		WTime st(start_time, m_timeManager), et(end_time, m_timeManager);
 		ScenarioExportRules rr;
-		HRESULT hr = m_impl->m_scenario->Export(set, &st, &et, flags, driver_name.c_str(), projection.c_str(), file_path.c_str(), *rules);
+		HRESULT hr = m_impl->m_scenario->Export(set, &st, &et, flags, driver_name, projection, file_path, *rules);
 		if (SUCCEEDED(hr)) {
 			start_time.SetTime(st);
 			end_time.SetTime(et);
@@ -64,9 +64,9 @@ HRESULT CCWFGM_Scenario::ExportFires(const CCWFGM_Ignition *set, HSS_Time::WTime
 
 
 HRESULT CCWFGM_Scenario::ExportCriticalPath(const ICWFGM_Asset* asset, const std::uint32_t index, const std::uint16_t flags,
-	const std::string& driver_name, const std::string& projection, const std::string& file_path, const ScenarioExportRules* rules) const {
+	std::string_view driver_name, const std::string& projection, const std::filesystem::path& file_path, const ScenarioExportRules* rules) const {
 	if (!driver_name.length())									return E_POINTER;
-	if (!file_path.length())									return E_POINTER;
+	if (file_path.empty())										return E_POINTER;
 
 	CRWThreadSemaphoreEngage _semaphore_engage(const_cast<CRWThreadSemaphore&>(m_lock), SEM_FALSE);
 
@@ -94,7 +94,7 @@ HRESULT CCWFGM_Scenario::ExportCriticalPath(const ICWFGM_Asset* asset, const std
 				if (!g)
 					return ERROR_SCENARIO_ASSET_GEOMETRY_UNKNOWN;
 			}
-			return m_impl->m_scenario->ExportCriticalPath(node, g, flags, driver_name.c_str(), projection.c_str(), file_path.c_str(), *rules);
+			return m_impl->m_scenario->ExportCriticalPath(node, g, flags, driver_name, projection, file_path, *rules);
 		}
 		node = node->LN_Succ();
 	}

--- a/cpp/scenario.cpp
+++ b/cpp/scenario.cpp
@@ -42,7 +42,6 @@
 #ifdef __GNUC__
 #define BOOST_CHRONO_HEADER_ONLY
 #endif
-#include "boost_ll_config.h"
 #include <boost/chrono.hpp>
 
 #ifdef _MSC_VER
@@ -1305,7 +1304,7 @@ public:
 
 template<class _type>
 HRESULT Scenario<_type>::Export(const CCWFGM_Ignition *ignition, WTime *start_time, WTime *end_time, std::uint16_t flags,
-	const TCHAR *driver_name, const TCHAR *csProjection, const TCHAR *file_path,
+	std::string_view driver_name, const std::string &csProjection, const std::filesystem::path &file_path,
     const ScenarioExportRules &rules, ScenarioTimeStep<_type> *_sts) const {
 	CRWThreadSemaphoreEngage _semaphore_engage(*(CRWThreadSemaphore *)&m_llLock, SEM_FALSE);
 
@@ -1318,7 +1317,7 @@ HRESULT Scenario<_type>::Export(const CCWFGM_Ignition *ignition, WTime *start_ti
 	CSemaphoreEngage lock(GDALClient::GDALClient::getGDALMutex(), true);
 
 	OGRSpatialReferenceH oSourceSRS = CCoordinateConverter::CreateSpatialReferenceFromWkt(projection.c_str());
-	OGRSpatialReferenceH oTargetSRS = CCoordinateConverter::CreateSpatialReferenceFromStr(csProjection);
+	OGRSpatialReferenceH oTargetSRS = CCoordinateConverter::CreateSpatialReferenceFromStr(csProjection.c_str());
 
 	ScenarioTimeStep<_type> *sts;
 	if (!_sts) {
@@ -1668,7 +1667,9 @@ HRESULT Scenario<_type>::BuildCriticalPath(const AssetNode<_type>* node, const A
 
 
 template<class _type>
-HRESULT Scenario<_type>::ExportCriticalPath(const AssetNode<_type>* node, const AssetGeometryNode<_type>* g, const std::uint16_t flags, const TCHAR* driver_name, const TCHAR* csProjection, const TCHAR* file_path, const ScenarioExportRules& rules) const {
+HRESULT Scenario<_type>::ExportCriticalPath(const AssetNode<_type>* node, const AssetGeometryNode<_type>* g, const std::uint16_t flags,
+	std::string_view driver_name, const std::string &csProjection, const std::filesystem::path &file_path,
+	const ScenarioExportRules& rules) const {
 	if (g) {
 	if (!g->m_arrived)
 		return ERROR_SCENARIO_ASSET_NOT_ARRIVED;
@@ -1680,7 +1681,7 @@ HRESULT Scenario<_type>::ExportCriticalPath(const AssetNode<_type>* node, const 
 	std::string projection = std::get<std::string>(var);
 
 	OGRSpatialReferenceH oSourceSRS = CCoordinateConverter::CreateSpatialReferenceFromWkt(projection.c_str());
-	OGRSpatialReferenceH oTargetSRS = CCoordinateConverter::CreateSpatialReferenceFromStr(csProjection);
+	OGRSpatialReferenceH oTargetSRS = CCoordinateConverter::CreateSpatialReferenceFromStr(csProjection.c_str());
 
 	CriticalPath polyset;
 	if (g) {

--- a/include/CWFGM_Fire.h
+++ b/include/CWFGM_Fire.h
@@ -55,7 +55,7 @@ public:
 class SerializeIgnitionData : public ISerializationData
 {
 public:
-	std::vector<std::string> *permissible_drivers;
+	std::vector<std::string_view> *permissible_drivers;
 };
 
 
@@ -298,7 +298,7 @@ public:
 		\retval ERROR_IGNITION_UNINITIALIZED Specified grid is invalid or not provided
 		\retval ERROR_FIRE_IGNITION_TYPE_UNKNOWN Unknown ignition type (not point, line, polygon)
 	*/
-	virtual NO_THROW HRESULT ImportIgnition(const std::string &file_name, const std::vector<std::string> *permissible_drivers, const std::vector<std::string>* attribute_name);
+	virtual NO_THROW HRESULT ImportIgnition(const std::filesystem::path &file_name, const std::vector<std::string_view> &permissible_drivers, const std::vector<std::string>* attribute_name);
 	/** Imports an ignition from the WFS URL specified.
 		\param	url		Identifies the WFS provider.
 		\param	layer	Identifies the layer in the WFS provider.
@@ -327,7 +327,7 @@ public:
 		\retval ERROR_SEVERITY_WARNING Unspecified failure
 		\retval ERROR_IGNITION_UNINITIALIZED Specified grid is invalid or not provided
 	*/
-	virtual NO_THROW HRESULT ExportIgnition(const std::string &driver_name, const std::string &projection, const std::string &file_name);
+	virtual NO_THROW HRESULT ExportIgnition(std::string_view driver_name, const std::string &projection, const std::filesystem::path &file_name);
 	/** Exports the ignition to the specified file path.
 		\param	url		Identifies the WFS provider.
 		\param	layer	Identifies the layer in the WFS provider.

--- a/include/CWFGM_Scenario.h
+++ b/include/CWFGM_Scenario.h
@@ -856,8 +856,8 @@ public:
 		\retval S_FALSE Unspecified error
 		\retval E_FAIL Unspecidifed error
 	*/
-	virtual NO_THROW HRESULT ExportFires(const CCWFGM_Ignition *set, HSS_Time::WTime &start_time, HSS_Time::WTime &end_time, std::uint16_t flags,const std::string &driver_name, const std::string &projection, const std::string &file_path, const class ScenarioExportRules *rules) const;
-	virtual NO_THROW HRESULT ExportCriticalPath(const ICWFGM_Asset* asset, const std::uint32_t index, const std::uint16_t flags, const std::string& driver_name, const std::string& projection, const std::string& file_path, const ScenarioExportRules* rules) const;
+	virtual NO_THROW HRESULT ExportFires(const CCWFGM_Ignition *set, HSS_Time::WTime &start_time, HSS_Time::WTime &end_time, std::uint16_t flags,std::string_view driver_name, const std::string &projection, const std::filesystem::path &file_path, const class ScenarioExportRules *rules) const;
+	virtual NO_THROW HRESULT ExportCriticalPath(const ICWFGM_Asset* asset, const std::uint32_t index, const std::uint16_t flags, std::string_view driver_name, const std::string& projection, const std::filesystem::path& file_path, const ScenarioExportRules* rules) const;
 	virtual NO_THROW HRESULT BuildCriticalPath(const ICWFGM_Asset* asset, const std::uint32_t index, const std::uint16_t flags, MinListTempl<CriticalPath>& polyset, const ScenarioExportRules* rules) const;
 
 	virtual NO_THROW HRESULT GetPercentileClassCount(unsigned char *count);

--- a/include/scenario.h
+++ b/include/scenario.h
@@ -128,8 +128,8 @@ public:
 
 	HRESULT GetStats(const XY_Point &min_utmpt, const XY_Point& max_utmpt, const XYPointType& pt1, const XYPointType& pt2, WTime* mintime, WTime* time, std::uint16_t stat_cnt, std::uint16_t* stats_array, NumericVariant* vstats, bool only_displayable, std::uint32_t technique, std::uint16_t discretize, bool test);
 
-	HRESULT Export(const CCWFGM_Ignition *set, WTime *start_time, WTime *end_time, std::uint16_t flags, const TCHAR *driver_name, const TCHAR *projection, const TCHAR *file_path, const ScenarioExportRules &rules, ScenarioTimeStep<_type> *_sts = nullptr) const;
-	HRESULT ExportCriticalPath(const AssetNode<_type>* node, const AssetGeometryNode<_type>* g, const std::uint16_t flags, const TCHAR* driver_name, const TCHAR* csProjection, const TCHAR* file_path, const ScenarioExportRules& rules) const;
+	HRESULT Export(const CCWFGM_Ignition *set, WTime *start_time, WTime *end_time, std::uint16_t flags, std::string_view driver_name, const std::string &projection, const std::filesystem::path &file_path, const ScenarioExportRules& rules, ScenarioTimeStep<_type>* _sts = nullptr) const;
+	HRESULT ExportCriticalPath(const AssetNode<_type>* node, const AssetGeometryNode<_type>* g, const std::uint16_t flags, std::string_view driver_name, const std::string& csProjection, const std::filesystem::path& file_path, const ScenarioExportRules& rules) const;
 	HRESULT BuildCriticalPath(const AssetNode<_type>* node, const AssetGeometryNode<_type>* g, const std::uint16_t flags, CriticalPath* polyset, const ScenarioExportRules* rules) const;
 
 	std::vector<class FirePoint<_type>*>	m_omp_fp_array;


### PR DESCRIPTION
The list used to be a raw array that relied on having a null at the end, change to a std::vector.