### PR TITLE
Remove unused include

### DIFF
--- a/cpp/scenario.cpp
+++ b/cpp/scenario.cpp
@@ -42,7 +42,6 @@
 #ifdef __GNUC__
 #define BOOST_CHRONO_HEADER_ONLY
 #endif
-#include "boost_ll_config.h"
 #include <boost/chrono.hpp>
 
 #ifdef _MSC_VER


### PR DESCRIPTION
The boost_ll_config header file hasn't been needed in a while, remove it from scenario.cpp.