### PR TITLE
Fix for premature exit of simulations

### DIFF
--- a/cpp/FireStateGrow.cpp
+++ b/cpp/FireStateGrow.cpp
@@ -717,12 +717,14 @@ bool ScenarioTimeStep<_type>::CheckAssets(bool& make_displayable) {
 			an = an->LN_Succ();
 		}
 
-		if (m_scenario->m_scenario->m_globalAssetOperation == (std::uint32_t)-1) {
-			if (globalCount == fullCount)
-				exit = true;
-		} else if (m_scenario->m_scenario->m_globalAssetOperation > 0) {
-			if (globalCount >= m_scenario->m_scenario->m_globalAssetOperation)
-				exit = true;
+		if (globalCount) {
+			if (m_scenario->m_scenario->m_globalAssetOperation == (std::uint32_t)-1) {
+				if (globalCount == fullCount)
+					exit = true;
+			} else if (m_scenario->m_scenario->m_globalAssetOperation > 0) {
+				if (globalCount >= m_scenario->m_scenario->m_globalAssetOperation)
+					exit = true;
+			}
 		}
 	}
 


### PR DESCRIPTION
Fix for https://github.com/WISE-Developers/WISE_Scenario_Growth_Module/issues/11

This issue created incorrect outputs on some fires modelled for the recent Alberta project.